### PR TITLE
fix(format): incorrect format tab size

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                     },
                     "vscode-vdf.popfile.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `-1` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
                         "default": -1
                     },
                     "vscode-vdf.popfile.suggest.enable": {
@@ -169,7 +169,7 @@
                     },
                     "vscode-vdf.vmt.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `-1` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
                         "default": 1
                     },
                     "vscode-vdf.vmt.suggest.enable": {
@@ -194,7 +194,7 @@
                     },
                     "vscode-vdf.vdf.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `-1` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
                         "default": 1
                     },
                     "vscode-vdf.vdf.suggest.enable": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                     },
                     "vscode-vdf.popfile.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert between keys and values when formatting. `0` = Insert a single space",
                         "default": -1
                     },
                     "vscode-vdf.popfile.suggest.enable": {
@@ -169,7 +169,7 @@
                     },
                     "vscode-vdf.vmt.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert between keys and values when formatting. `0` = Insert a single space",
                         "default": 1
                     },
                     "vscode-vdf.vmt.suggest.enable": {
@@ -194,7 +194,7 @@
                     },
                     "vscode-vdf.vdf.format.tabs": {
                         "type": "number",
-                        "markdownDescription": "How many tabs to insert betweens keys and values when formatting. `0` = Insert a single space",
+                        "markdownDescription": "How many tabs to insert between keys and values when formatting. `0` = Insert a single space",
                         "default": 1
                     },
                     "vscode-vdf.vdf.suggest.enable": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
                     "vscode-vdf.popfile.format.tabs": {
                         "type": "number",
                         "markdownDescription": "How many tabs to insert between keys and values when formatting. `0` = Insert a single space",
-                        "default": -1
+                        "default": 0
                     },
                     "vscode-vdf.popfile.suggest.enable": {
                         "type": "boolean",

--- a/packages/lib/VDFFormat/printVDFFormatDocumentSymbols.ts
+++ b/packages/lib/VDFFormat/printVDFFormatDocumentSymbols.ts
@@ -24,11 +24,11 @@ export function printVDFFormatDocumentSymbols(documentSymbols: VDFFormatDocument
 		? (level: number): string => tab.repeat(level)
 		: (level: number): string => space.repeat(level * _options.tabSize)
 
-	const getWhitespace: (longest: number, current: number) => string = _options.tabs == -1
+	const getWhitespace: (longest: number, current: number) => string = _options.tabs == 0
 		? (): string => space
 		: tabIndentation
 			? _options.quotes
-				? (longest: number, current: number): string => tab.repeat(Math.floor(((longest + 2) / 4) - Math.floor((current + 2) / 4)) + 1 + _options.tabs)
+				? (longest: number, current: number): string => tab.repeat(Math.floor(((longest + 2) / 4) - Math.floor((current + 2) / 4)) + _options.tabs)
 				: (longest: number, current: number): string => tab.repeat(Math.floor((longest / 4) - Math.floor(current / 4)) + 1 + _options.tabs)
 			: _options.quotes
 				? (longest: number, current: number): string => space.repeat((longest + 2) - (current + 2) + (4 - ((longest + 2) % 4)) + (_options.tabs * _options.tabSize))


### PR DESCRIPTION
## Issue
Currently, if tab size is set to 1
`"vscode-vdf.vdf.format.tabs": 1`

It would format the resource file with +1 extra tab, resulting in 2 tabs.

![image](https://github.com/cooolbros/vscode-vdf/assets/27555338/1aef8ac0-5e41-4fcb-88dd-52cde48e873c)

## Changes
- The setting represents the actual format tab space inbetween keys and values.
- Tab size 0 will replace all spaces with single space.
  The instructions are also updated to represent that
  `How many tabs to insert betweens keys and values when formatting. 0 = Insert a single space`
- Typo: `betweens` replaced with `between`