### PR TITLE
Popfile: Add `Delay` to I/O blocks

### DIFF
--- a/packages/server/src/VDF/Popfile/keys.json
+++ b/packages/server/src/VDF/Popfile/keys.json
@@ -182,6 +182,10 @@
             {
                 "label": "Param",
                 "kind": 7
+            },
+            {
+                "label": "Delay",
+                "kind": 7
             }
         ]
     },


### PR DESCRIPTION
`Delay` is also a valid key for I/O blocks, much like that from `EntFire()`.