### PR TITLE
multiline tags, tag length checking, update tsconfig, show buffer lengths

### DIFF
--- a/packages/client/src/commands/importPopfileTemplates.ts
+++ b/packages/client/src/commands/importPopfileTemplates.ts
@@ -9,7 +9,7 @@ import { fileSystemMountPointFactory } from "../VirtualFileSystem/FileSystemMoun
 const TFBotSquadRandomChoice = ["TFBot", "Squad", "RandomChoice"].map(i => i.toLowerCase())
 
 export async function importPopfileTemplates(editor: TextEditor): Promise<void> {
-	const options = { multilineStrings: new Set(["Param".toLowerCase()]) }
+	const options = { multilineStrings: new Set(["Param".toLowerCase(), "Tag".toLowerCase()]) }
 
 	const documentSymbols = getVDFDocumentSymbols(editor.document.getText(), options)
 

--- a/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
+++ b/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
@@ -485,7 +485,7 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 		// https://github.com/cooolbros/vscode-vdf/issues/29
 		// Tags are limited to 256 characters due to CFmtStr
 		const valueLengthValidation = PopfileTextDocument.Schema.valueLengthValidation
-		if (valueLengthValidation && valueLengthValidation[key] && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= valueLengthValidation[key])) {
+		if (valueLengthValidation?.[key] && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= valueLengthValidation[key])) {
 			return {
 				range: documentSymbol.detailRange!,
 				severity: DiagnosticSeverity.Warning,

--- a/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
+++ b/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
@@ -491,7 +491,7 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 				severity: DiagnosticSeverity.Warning,
 				code: "invalid-length",
 				source: "popfile",
-				message: `Value exceeds maximum buffer size (${valueLengthValidation[key]}).`,
+				message: `Value exceeds maximum buffer size (${valueLengthValidation[key]}, got ${documentSymbol.detail.length + "\0".length}).`,
 			}
 		}
 

--- a/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
+++ b/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
@@ -485,7 +485,7 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 		// https://github.com/cooolbros/vscode-vdf/issues/29
 		// Tags are limited to 256 characters due to CFmtStr
 		const valueLengthValidation = PopfileTextDocument.Schema.valueLengthValidation
-		if (valueLengthValidation?.[key] && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= valueLengthValidation[key])) {
+		if (valueLengthValidation && valueLengthValidation[key] && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= valueLengthValidation[key])) {
 			return {
 				range: documentSymbol.detailRange!,
 				severity: DiagnosticSeverity.Warning,

--- a/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
+++ b/packages/server/src/VDF/Popfile/PopfileTextDocument.ts
@@ -154,6 +154,10 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 			],
 			typeKey: null,
 			defaultType: null,
+		},
+		valueLengthValidation: {
+			"param": 2 ** 12,
+			"tag": 2 ** 8,
 		}
 	}
 
@@ -170,7 +174,7 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 	) {
 		super(init, documentConfiguration, fileSystem$, documents, refCountDispose, {
 			relativeFolderPath: "scripts/population",
-			VDFParserOptions: { multilineStrings: new Set(["Param".toLowerCase()]) },
+			VDFParserOptions: { multilineStrings: new Set(["Param".toLowerCase(), "Tag".toLowerCase()]) },
 			keyTransform: (key) => key,
 			dependencies$: fileSystem$.pipe(
 				switchMap((fileSystem) => {
@@ -478,15 +482,16 @@ export class PopfileTextDocument extends VDFTextDocument<PopfileTextDocument> {
 				}
 			}
 		}
-
 		// https://github.com/cooolbros/vscode-vdf/issues/29
-		if (key == "Param".toLowerCase() && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= 2 ** 12)) {
+		// Tags are limited to 256 characters due to CFmtStr
+		const valueLengthValidation = PopfileTextDocument.Schema.valueLengthValidation
+		if (valueLengthValidation?.[key] && documentSymbol.detail && ((documentSymbol.detail.length + "\0".length) >= valueLengthValidation[key])) {
 			return {
 				range: documentSymbol.detailRange!,
 				severity: DiagnosticSeverity.Warning,
 				code: "invalid-length",
 				source: "popfile",
-				message: "Value exceeds maximum buffer size.",
+				message: `Value exceeds maximum buffer size (${valueLengthValidation[key]}).`,
 			}
 		}
 

--- a/packages/server/src/VDF/VDFTextDocument.ts
+++ b/packages/server/src/VDF/VDFTextDocument.ts
@@ -109,6 +109,7 @@ export interface VDFTextDocumentSchema {
 		defaultType: string | null
 		values?: Record<string, { kind: CompletionItemKind, values: string[] }>
 	}
+	valueLengthValidation?: Record<string, number>
 }
 
 export interface DefinitionMatcher {

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -108,9 +108,11 @@
   },
   "ts-node": {
     "compilerOptions": {
-        "module": "CommonJS",
+        "module": "ESNext",
+        "moduleResolution": "node",
         "types": ["node"],
         "verbatimModuleSyntax": false
-    }
+    },
+    "esm": true
   }
 }


### PR DESCRIPTION
tsconfig out of the box wouldn't compile with CommonJS before making any changes due to the import syntax, if this is wrong I'll revert.